### PR TITLE
missing standardization of X_test

### DIFF
--- a/experiment/evaluate_model.py
+++ b/experiment/evaluate_model.py
@@ -42,7 +42,8 @@ def evaluate_model(dataset, results_path, random_state, est_name, est,
                                                     test_size=0.25,
                                                     random_state=random_state)
     # scale and normalize the data
-    X_train = StandardScaler().fit_transform(X_train)
+    sc_x = StandardScaler()
+    X_train = sc_x.fit_transform(X_train)
     sc_y = StandardScaler()
     y_train = sc_y.fit_transform(y_train.reshape(-1,1)).flatten()
     print('X_train:',X_train.shape)
@@ -112,23 +113,24 @@ def evaluate_model(dataset, results_path, random_state, est_name, est,
 
     # scores
     sc_inv = sc_y.inverse_transform
+    X_test_std = sc_x.transform(X_test)
     pred = grid_est.predict
     # mse
     results['train_score_mse'] = mean_squared_error(sc_inv(y_train), 
                                                     sc_inv(pred(X_train)))
     results['test_score_mse'] = mean_squared_error(y_test, 
-                                                   sc_inv(pred(X_test)))
+                                                   sc_inv(pred(X_test_std)))
 
     # mae 
     results['train_score_mae'] = mean_absolute_error(sc_inv(y_train), 
                                                      sc_inv(pred(X_train)))
     results['test_score_mae'] = mean_absolute_error(y_test, 
-                                                    sc_inv(pred(X_test)))
+                                                    sc_inv(pred(X_test_std)))
 
     # r2 
     results['train_score_r2'] = r2_score(sc_inv(y_train), 
                                          sc_inv(pred(X_train)))
-    results['test_score_r2'] = r2_score(y_test, sc_inv(pred(X_test)))
+    results['test_score_r2'] = r2_score(y_test, sc_inv(pred(X_test_std)))
 
     
     ##################################################


### PR DESCRIPTION
Only X_train was being standardized. 

I've just created a variable named `X_test_std` that was created by:

```python
sc_x = StandardScaler()
X_train = sc_x.fit_transform(X_train)
X_test_std = sc_x.transform(X_test)
```

and then replaced the use of `X_test` with `X_test_std`